### PR TITLE
fix(theme): enforce black text on HorizontalScrollTech and PostList c…

### DIFF
--- a/apps/web/components/HorizontalScrollTech.tsx
+++ b/apps/web/components/HorizontalScrollTech.tsx
@@ -54,7 +54,7 @@ interface HorizontalScrollTechProps {
 
 const HorizontalScrollTech: React.FC<HorizontalScrollTechProps> = ({ reverse = false }) => {
   return (
-    <div className={`px-5 dark:text-blog-white gap-8 flex items-center justify-center md:justify-start [&_li]:mx-8 [&_img]:max-w-none  ${reverse ? 'animate-infinite-scroll' : 'animate-infinite-reverse'}`}>
+    <div className={`px-5 text-blog-black dark:text-blog-white gap-8 flex items-center justify-center md:justify-start [&_li]:mx-8 [&_img]:max-w-none  ${reverse ? 'animate-infinite-scroll' : 'animate-infinite-reverse'}`}>
       <FontAwesomeIcon icon={faJava} size="8x" className={'text-[#5986a4]'} />
       <Image
         src={spring}

--- a/apps/web/components/PostList.tsx
+++ b/apps/web/components/PostList.tsx
@@ -37,7 +37,7 @@ const PostList: React.FC<PostListProps> = ({ posts, loading = false, postsEnd = 
 
         return (
             <Link key={post.slug} className="flex py-6 hover:py-4 min-w-fit" href={`/${post.username}/${post.slug}`}>
-                <div className="p-6 hover:px-8 flex lg:mx-0 mx-3 bg-blog-white dark:bg-fun-blue-600 dark:text-blog-white hover:rounded-3xl rounded-3xl drop-shadow-lg hover:drop-shadow-xl hover:brightness-125 max-w-md w-full">
+                <div className="p-6 hover:px-8 flex lg:mx-0 mx-3 bg-blog-white text-blog-black dark:bg-fun-blue-600 dark:text-blog-white hover:rounded-3xl rounded-3xl drop-shadow-lg hover:drop-shadow-xl hover:brightness-125 max-w-md w-full">
                     <div className="flex flex-col gap-4 justify-between w-full">
                         {/* DATE and Author */}
                         <div>


### PR DESCRIPTION
This pull request updates the color theme handling for key UI components to improve text visibility in light mode. The main changes ensure that text is explicitly set to `text-blog-black` in light mode, preventing issues where text could appear with the wrong color.

**Color theme improvements:**

* [`apps/web/components/HorizontalScrollTech.tsx`](diffhunk://#diff-bc88675c6e5b0ce4153ee96799fd5dd04a65d203396bd24414450ea7d03e8857L57-R57): Added `text-blog-black` to the container so text is correctly displayed in light mode, alongside the existing dark mode styling.
* [`apps/web/components/PostList.tsx`](diffhunk://#diff-8636a8936c12b595d12cb84ab44bf62b7fbae727dcb437023f1ccfc7f211a491L40-R40): Added `text-blog-black` to the post container for light mode, ensuring consistent text color regardless of theme.…omponents for better contrast