### PR TITLE
fix(profile): use client-only JsonForms wrapper to avoid SSR/runtime …

### DIFF
--- a/apps/web/components/JsonFormsClient.tsx
+++ b/apps/web/components/JsonFormsClient.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import React from "react";
+import { JsonForms } from "@jsonforms/react";
+import { materialCells, materialRenderers } from "@jsonforms/material-renderers";
+
+interface Props {
+  schema: any;
+  uischema: any;
+  data: any;
+  onChange: (e: any) => void;
+}
+
+export default function JsonFormsClient({ schema, uischema, data, onChange }: Props) {
+  return (
+    <JsonForms
+      schema={schema}
+      uischema={uischema}
+      data={data}
+      renderers={materialRenderers}
+      cells={materialCells}
+      onChange={onChange}
+    />
+  );
+}

--- a/apps/web/pages/profile.tsx
+++ b/apps/web/pages/profile.tsx
@@ -13,18 +13,15 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Chip from "@mui/material/Chip";
 
 // JSON FORMS
-import { JsonForms } from "@jsonforms/react";
+import dynamic from "next/dynamic";
+
+const JsonFormsClient = dynamic(() => import("../components/JsonFormsClient"), { ssr: false });
 
 import schema from "../lib/experiences/experiencesSchema.json";
 import uischema from "../lib/experiences/uiExperiencesSchema.json";
 
 import skillSchema from "../lib/skills/skillsSchema.json";
 import uiSkillSchema from "../lib/skills/uiSkillsSchema.json";
-
-import {
-  materialCells,
-  materialRenderers,
-} from "@jsonforms/material-renderers";
 
 // Supabase Interfaces
 import { EXPERIENCES, EXPERIENCES_INSERT_DATA } from "../database.types";


### PR DESCRIPTION
This pull request refactors how the JSON Forms component is used in the profile page by introducing a new client-side wrapper component. The main goal is to ensure that the JSON Forms rendering is handled only on the client side, which is important for compatibility with Next.js and Material UI.

Component extraction and dynamic import:

* Added a new `JsonFormsClient` component in `apps/web/components/JsonFormsClient.tsx` to encapsulate the JSON Forms logic and enforce client-side rendering.
* Updated `apps/web/pages/profile.tsx` to use a dynamic import for `JsonFormsClient` with server-side rendering disabled (`ssr: false`), replacing direct usage of `JsonForms` and related imports.…errors