### PR TITLE
Migrate/pages approve index

### DIFF
--- a/apps/web/pages/appointment-page/index.tsx
+++ b/apps/web/pages/appointment-page/index.tsx
@@ -3,18 +3,18 @@ import React from "react";
 
 const AppointmentPage = () => {
   return (
-    <div className="flex flex-col h-screen justify-between items-center">
+    <div className="flex flex-col h-screen justify-between items-center text-blog-black dark:text-blog-white">
       <div className="flex flex-col justify-between items-center">
-        <div className="mt-10 text-3xl dark:text-blog-white text-blog-black font-bold leading-none tracking-tight md:text-5xl lg:text-6xl">
+        <div className="mt-10 text-3xl text-blog-black dark:text-blog-white font-bold leading-none tracking-tight md:text-5xl lg:text-6xl">
           Appointment Page
         </div>
-        <div className="md:text-xl lg:text-2xl text-base dark:text-blog-white text-blog-black font-thin leading-none tracking-tight">
+        <div className="md:text-xl lg:text-2xl text-base text-blog-black dark:text-blog-white font-thin leading-none tracking-tight">
           Book the appointment with the doctor
         </div>
-        <div className="md:text-xl lg:text-2xl text-base dark:text-blog-white text-blog-black font-thin leading-none tracking-tight">
+        <div className="md:text-xl lg:text-2xl text-base text-blog-black dark:text-blog-white font-thin leading-none tracking-tight">
           Calendar - Pick a Date
         </div>
-        <div className="md:text-xl lg:text-2xl text-base dark:text-blog-white text-blog-black font-thin leading-none tracking-tight">
+        <div className="md:text-xl lg:text-2xl text-base text-blog-black dark:text-blog-white font-thin leading-none tracking-tight">
           Calendar - Pick a Time
         </div>
       </div>
@@ -24,7 +24,7 @@ const AppointmentPage = () => {
             className="focus:outline-none focus:ring-2 
                       focus:ring-hit-pink-400 
                       focus:ring-offset-2 text-xl
-                      font-semibold bg-hit-pink-500 dark:text-blog-black 
+                      font-semibold text-blog-black dark:text-blog-white bg-hit-pink-500 
                       p-2 m-1 flex rounded items-center justify-center gap-x-2
                       transition-filter duration-500 hover:filter hover:brightness-125"
           >

--- a/apps/web/pages/approve/index.tsx
+++ b/apps/web/pages/approve/index.tsx
@@ -95,19 +95,19 @@ function ApprovePostList() {
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-blog-black dark:text-blog-white">
       {/* Header Section */}
       <div className="mb-8">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
-            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white">
+            <h1 className="text-2xl sm:text-3xl font-bold text-blog-black dark:text-blog-white">
               <FormattedMessage
                 id="approve-title"
                 description="Content Moderation"
                 defaultMessage="Content Moderation"
               />
             </h1>
-            <p className="text-gray-600 dark:text-blog-white mt-2">
+            <p className="text-gray-600 dark:text-gray-300 mt-2">
               <FormattedMessage
                 id="approve-subtitle"
                 description="Review and approve user-submitted content"
@@ -118,18 +118,18 @@ function ApprovePostList() {
           
           {/* Quick Stats */}
           <div className="flex items-center gap-4">
-            <div className="bg-white dark:bg-fun-blue-600 rounded-lg px-4 py-2 border border-gray-200 dark:border-fun-blue-500">
-              <div className="text-sm text-gray-600 dark:text-blog-white">
+            <div className="bg-white card--white dark:bg-fun-blue-600 rounded-lg px-4 py-2 border border-gray-200 dark:border-fun-blue-500">
+              <div className="text-sm text-gray-600 dark:text-gray-300">
                 <FormattedMessage
                   id="approve-stats-total"
                   description="Total Posts"
                   defaultMessage="Total Posts"
                 />
               </div>
-              <div className="text-xl font-bold text-gray-900 dark:text-white">{posts.length}</div>
+              <div className="text-xl font-bold text-blog-black dark:text-blog-white">{posts.length}</div>
             </div>
-            <div className="bg-white dark:bg-fun-blue-600 rounded-lg px-4 py-2 border border-gray-200 dark:border-fun-blue-500">
-              <div className="text-sm text-gray-600 dark:text-blog-white">
+            <div className="bg-white card--white dark:bg-fun-blue-600 rounded-lg px-4 py-2 border border-gray-200 dark:border-fun-blue-500">
+              <div className="text-sm text-gray-600 dark:text-gray-300">
                 <FormattedMessage
                   id="approve-stats-pending"
                   description="Pending"
@@ -140,8 +140,8 @@ function ApprovePostList() {
                 {posts.filter(post => !post.approved).length}
               </div>
             </div>
-            <div className="bg-white dark:bg-fun-blue-600 rounded-lg px-4 py-2 border border-gray-200 dark:border-fun-blue-500">
-              <div className="text-sm text-gray-600 dark:text-blog-white">
+            <div className="bg-white card--white dark:bg-fun-blue-600 rounded-lg px-4 py-2 border border-gray-200 dark:border-fun-blue-500">
+              <div className="text-sm text-gray-600 dark:text-gray-300">
                 <FormattedMessage
                   id="approve-stats-approved"
                   description="Approved"
@@ -158,13 +158,13 @@ function ApprovePostList() {
         {/* Filter Tabs */}
         <div className="mt-6 border-b border-gray-200 dark:border-fun-blue-500">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
-            <nav className="-mb-px flex space-x-8">
+              <nav className="-mb-px flex space-x-8">
               <button 
                 onClick={() => setActiveTab('all')}
                 className={`py-2 px-1 border-b-2 font-medium text-sm ${
                   activeTab === 'all'
-                    ? 'border-fun-blue-500 text-fun-blue-600 dark:text-caribbean-green-400'
-                    : 'border-transparent text-gray-500 dark:text-blog-white hover:text-gray-700 dark:hover:text-blog-white hover:border-gray-300 dark:hover:border-gray-600'
+                    ? 'border-fun-blue-500 text-fun-blue-600 dark:text-blog-white'
+                    : 'border-transparent text-gray-500 dark:text-gray-300 hover:text-gray-700 dark:hover:text-blog-white hover:border-gray-300 dark:hover:border-gray-600'
                 }`}
               >
                 <FormattedMessage
@@ -177,8 +177,8 @@ function ApprovePostList() {
                 onClick={() => setActiveTab('pending')}
                 className={`py-2 px-1 border-b-2 font-medium text-sm ${
                   activeTab === 'pending'
-                    ? 'border-fun-blue-500 text-fun-blue-600 dark:text-caribbean-green-400'
-                    : 'border-transparent text-gray-500 dark:text-blog-white hover:text-gray-700 dark:hover:text-blog-white hover:border-gray-300 dark:hover:border-gray-600'
+                    ? 'border-fun-blue-500 text-fun-blue-600 dark:text-blog-white'
+                    : 'border-transparent text-gray-500 dark:text-gray-300 hover:text-gray-700 dark:hover:text-blog-white hover:border-gray-300 dark:hover:border-gray-600'
                 }`}
               >
                 <FormattedMessage
@@ -191,8 +191,8 @@ function ApprovePostList() {
                 onClick={() => setActiveTab('approved')}
                 className={`py-2 px-1 border-b-2 font-medium text-sm ${
                   activeTab === 'approved'
-                    ? 'border-fun-blue-500 text-fun-blue-600 dark:text-caribbean-green-400'
-                    : 'border-transparent text-gray-500 dark:text-blog-white hover:text-gray-700 dark:hover:text-blog-white hover:border-gray-300 dark:hover:border-gray-600'
+                    ? 'border-fun-blue-500 text-fun-blue-600 dark:text-blog-white'
+                    : 'border-transparent text-gray-500 dark:text-gray-300 hover:text-gray-700 dark:hover:text-blog-white hover:border-gray-300 dark:hover:border-gray-600'
                 }`}
               >
                 <FormattedMessage
@@ -219,7 +219,7 @@ function ApprovePostList() {
                   description: 'Search posts...',
                   defaultMessage: 'Search posts...'
                 })}
-                className="block w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-fun-blue-400 rounded-md leading-5 bg-white dark:bg-fun-blue-700 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-fun-blue-500 focus:border-transparent sm:text-sm"
+                className="block w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-fun-blue-400 rounded-md leading-5 bg-white card--white dark:bg-fun-blue-700 placeholder-gray-500 dark:placeholder-gray-400 text-blog-black dark:text-blog-white focus:outline-none focus:ring-2 focus:ring-fun-blue-500 focus:border-transparent sm:text-sm"
               />
             </div>
           </div>
@@ -228,7 +228,7 @@ function ApprovePostList() {
 
       {/* Loading State */}
       {loading ? (
-        <div className="flex items-center justify-center py-12">
+          <div className="flex items-center justify-center py-12">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-fun-blue-500"></div>
           <span className="ml-3 text-gray-600 dark:text-blog-white">
             <FormattedMessage
@@ -270,7 +270,7 @@ function ApprovePostList() {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
               </div>
-              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+              <h3 className="text-lg font-medium text-blog-black dark:text-blog-white mb-2">
                 {searchTerm ? (
                   <FormattedMessage
                     id="approve-no-search-results-title"
@@ -297,7 +297,7 @@ function ApprovePostList() {
                   />
                 )}
               </h3>
-              <p className="text-gray-500 dark:text-blog-white mb-6">
+              <p className="text-gray-500 dark:text-gray-300 mb-6">
                 {searchTerm ? (
                   <FormattedMessage
                     id="approve-no-search-results-description"

--- a/migrate/COMPONENTS-MIGRATED.md
+++ b/migrate/COMPONENTS-MIGRATED.md
@@ -1,0 +1,22 @@
+# Migrated Components Manifest
+
+This file tracks components that have already been migrated as part of a page migration.
+
+Completed (migrated and verified):
+
+- apps/web/components/PostFeed.tsx
+- apps/web/components/Loader.tsx
+- apps/web/components/PostList.tsx (updated to enforce `card--white`)
+- apps/web/components/HorizontalScrollTech.tsx (applies `text-blog-black` token)
+- apps/web/components/Metatags.tsx
+- apps/web/components/JsonFormsClient.tsx (client-only wrapper for JsonForms)
+
+Policy:
+- Migrate a component on the first page that requires it.
+- Add its path below so subsequent page migrations skip re-migrating it.
+
+Notes:
+- If a migrated component receives follow-up fixes (contrast, tokens, or SSR guards), append a short note next to the component as shown above.
+
+Example:
+- apps/web/components/AwesomeNavBar.tsx

--- a/migrate/COMPONENTS-MIGRATED.md
+++ b/migrate/COMPONENTS-MIGRATED.md
@@ -11,6 +11,9 @@ Completed (migrated and verified):
 - apps/web/components/Metatags.tsx
 - apps/web/components/JsonFormsClient.tsx (client-only wrapper for JsonForms)
 
+Inspected / Notes:
+- apps/web/components/AuthCheck.tsx — inspected for `pages/approve` migration; no changes applied yet (pending conservative sweep for `bg-white` containers).
+
 Policy:
 - Migrate a component on the first page that requires it.
 - Add its path below so subsequent page migrations skip re-migrating it.

--- a/migrate/PAGES-QUEUE.md
+++ b/migrate/PAGES-QUEUE.md
@@ -1,0 +1,64 @@
+# Pages Migration Queue
+
+Order: root index (`/`) first, then remaining pages alphabetically.
+
+1. pages/index.tsx  # root — migrate first
+
+Completed:
+
+- pages/404.tsx (branch: migrate/pages-404)
+- pages/index.tsx (branch: migrate/pages-home)
+- pages/profile.tsx (branch: migrate/pages-profile)
+- pages/appointment-confirmed/index.tsx (branch: migrate/pages-appointment-confirmed)
+- pages/appointment-page/index.tsx (branch: migrate/pages-appointment-page)
+- pages/admin/index.tsx (branch: migrate/pages-admin-events)
+- pages/admin/events.tsx (branch: migrate/pages-admin-events)
+
+Other pages (alphabetical):
+
+- pages/404.tsx
+- pages/appointment-confirmed/index.tsx
+- pages/appointment-page/index.tsx
+- pages/approve/[slug].tsx
+- pages/approve/index.tsx
+- pages/admin/[slug].tsx
+- pages/admin/events.tsx
+- pages/admin/index.tsx
+- pages/book-appointment/index.tsx
+- pages/cancel.tsx
+- pages/cart/index.tsx
+- pages/choose-your-doctor/index.tsx
+- pages/checkout/index.tsx
+- pages/coverimage/index.tsx
+- pages/doctor-page/index.tsx
+- pages/enter.tsx
+- pages/favorites/index.tsx
+- pages/invite/index.tsx
+- pages/links.tsx
+- pages/play.tsx
+- pages/pics/index.tsx
+- pages/privacy-policy/index.tsx
+- pages/pricing/index.tsx
+- pages/product-detail/[id].tsx
+- pages/product-detail/index.tsx
+- pages/products/index.tsx
+- pages/profile.tsx
+- pages/rsvp/index.tsx
+- pages/success.tsx
+- pages/user-preferences.tsx
+- pages/[username]/[slug].tsx
+- pages/[username]/index.tsx
+
+Notes:
+- `_app.tsx` and `_document.tsx` are app-level files and are not part of per-page migrations.
+- API routes under `pages/api` are not migrated as pages.
+
+Instructions:
+- Create a branch `migrate/pages/<slug>` for each page when migrating.
+- After successful smoke test + lint + build, mark page as migrated and move to next.
+
+Recent updates:
+- `pages/profile.tsx` migrated and small-form containers converted to `bg-blog-white card--white`.
+- `pages/index.tsx` migrated; `PostList` and `HorizontalScrollTech` updated for theme tokens.
+- `pages/appointment-confirmed` and `pages/appointment-page` migrated and buttons updated to use body text tokens.
+- `pages/admin/index.tsx` and `pages/admin/events.tsx` were included in the admin migration branch.

--- a/migrate/PAGES-QUEUE.md
+++ b/migrate/PAGES-QUEUE.md
@@ -13,6 +13,7 @@ Completed:
 - pages/appointment-page/index.tsx (branch: migrate/pages-appointment-page)
 - pages/admin/index.tsx (branch: migrate/pages-admin-events)
 - pages/admin/events.tsx (branch: migrate/pages-admin-events)
+ - pages/approve/index.tsx (branch: migrate/pages-approve-index)
 
 Other pages (alphabetical):
 
@@ -62,3 +63,5 @@ Recent updates:
 - `pages/index.tsx` migrated; `PostList` and `HorizontalScrollTech` updated for theme tokens.
 - `pages/appointment-confirmed` and `pages/appointment-page` migrated and buttons updated to use body text tokens.
 - `pages/admin/index.tsx` and `pages/admin/events.tsx` were included in the admin migration branch.
+ - `pages/approve/index.tsx` migrated (branch: `migrate/pages-approve-index`) — page-level body tokens applied; quick-stat cards and search input changed to use `card--white`.
+ - `apps/web/components/PostFeed.tsx` inspected as part of the `approve` migration. `apps/web/components/AuthCheck.tsx` inspected; conservative fixes to `bg-white` containers are pending and will be applied in a small follow-up commit if required.


### PR DESCRIPTION
This pull request completes the migration of the `appointment-page` and `approve` pages to use the new design tokens and card styles, ensuring consistent light/dark theme support and improved accessibility. It also updates migration tracking documentation to reflect recent progress and clarifies component status and migration policy.

**Page and Component Theme Token Migration**

- Migrated `apps/web/pages/appointment-page/index.tsx` to use `text-blog-black` and `dark:text-blog-white` tokens for all text, ensuring proper color contrast in both light and dark modes.
- Refactored `apps/web/pages/approve/index.tsx` to:
  - Apply `text-blog-black` and `dark:text-blog-white` at the page and header level.
  - Update quick-stat cards and search input to use the `card--white` class and appropriate text tokens.
  - Adjust tab and empty-state styles for improved theme consistency and accessibility. [[1]](diffhunk://#diff-5ab661f19bdfded654e501447df2c4f99831813621279cac02b4b7f6cbea8c82L99-R111) [[2]](diffhunk://#diff-5ab661f19bdfded654e501447df2c4f99831813621279cac02b4b7f6cbea8c82L122-R133) [[3]](diffhunk://#diff-5ab661f19bdfded654e501447df2c4f99831813621279cac02b4b7f6cbea8c82L144-R145) [[4]](diffhunk://#diff-5ab661f19bdfded654e501447df2c4f99831813621279cac02b4b7f6cbea8c82L167-R168) [[5]](diffhunk://#diff-5ab661f19bdfded654e501447df2c4f99831813621279cac02b4b7f6cbea8c82L181-R182) [[6]](diffhunk://#diff-5ab661f19bdfded654e501447df2c4f99831813621279cac02b4b7f6cbea8c82L195-R196) [[7]](diffhunk://#diff-5ab661f19bdfded654e501447df2c4f99831813621279cac02b4b7f6cbea8c82L223-R223) [[8]](diffhunk://#diff-5ab661f19bdfded654e501447df2c4f99831813621279cac02b4b7f6cbea8c82L274-R274) [[9]](diffhunk://#diff-5ab661f19bdfded654e501447df2c4f99831813621279cac02b4b7f6cbea8c82L301-R301)

**Migration Documentation Updates**

- Updated `migrate/COMPONENTS-MIGRATED.md` to clarify which components have been migrated, their new paths, and to add notes about follow-up fixes or inspections. Added a section for inspected components and clarified the migration policy and notes.
- Updated `migrate/PAGES-QUEUE.md` to:
  - Mark `appointment-page`, `appointment-confirmed`, `admin`, and `approve` pages as migrated.
  - Add recent migration notes, including details on page-level token application and inspection status for components like `PostFeed` and `AuthCheck`. [[1]](diffhunk://#diff-f0161714e4c43cc19bd84944d2a97ba70fae3f568709f1f18a92b6fc820cb9f4L10-R16) [[2]](diffhunk://#diff-f0161714e4c43cc19bd84944d2a97ba70fae3f568709f1f18a92b6fc820cb9f4R64-R67)