### PR TITLE
fix(links): remove dark mode class for consistent heading styling

### DIFF
--- a/apps/web/pages/links.tsx
+++ b/apps/web/pages/links.tsx
@@ -335,7 +335,7 @@ export default function LinksPage({ locale }: LinksPageProps) {
           </div>
 
           {/* Name */}
-          <h1 className="text-2xl sm:text-3xl font-bold text-blog-black dark:text-blog-white mb-2">
+          <h1 className="text-2xl sm:text-3xl font-bold text-blog-black mb-2">
             Swapnil Srivastava
           </h1>
 


### PR DESCRIPTION
This pull request makes a minor change to the `LinksPage` component by removing the `dark:text-blog-white` class from the main heading. This will affect how the heading appears in dark mode.

testing the blog-white for testing