### PR TITLE
Migrate/pages rsvp

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -209,6 +209,7 @@
 - **Secondary Containers:** `bg-gray-50 dark:bg-fun-blue-700` for nested content
 - **Input Backgrounds:** `bg-white dark:bg-fun-blue-600` for form elements
 - **Hover Backgrounds:** `hover:bg-gray-50 dark:hover:bg-fun-blue-600`
+- **Theme-Aware Card Backgrounds:** Use current theme color (e.g., `bg-fun-blue-100`) in light mode and white (`bg-blog-white`) in dark mode for cards that should adapt to the theme (e.g., pricing cards).
 
 ### Component Styling Standards (CRITICAL)
 - **Always use Poppins font:** Either explicit `font-poppins` or rely on default

--- a/apps/web/pages/rsvp/index.tsx
+++ b/apps/web/pages/rsvp/index.tsx
@@ -1,9 +1,14 @@
 'use client';
 
 import React, { useEffect, useState } from "react";
+import type { NextPage } from 'next';
 
-function RSVP() {
-
+const RSVP: NextPage = () => {
+  return (
+    <main className="text-blog-black dark:text-blog-white">
+      {/* RSVP page content here */}
+    </main>
+  );
 };
 
 export default RSVP;

--- a/migrate/COMPONENTS-MIGRATED.md
+++ b/migrate/COMPONENTS-MIGRATED.md
@@ -24,7 +24,7 @@ Completed (migrated and verified):
 - Inspected for this migration: `apps/web/components/CheckoutButton.tsx` and `apps/web/components/Metatags.tsx` — no component-level changes required.
 
 - Inspected for this migration: `apps/web/pages/pics/index.tsx` — simple image page, no component changes required.
- - Inspected for this migration: `apps/web/components/CheckoutButton.tsx` — no component-level changes required.
+ - Inspected for this migration: `apps/web/pages/rsvp/index.tsx` — no component changes required.
 
 Inspected / Notes:
 - apps/web/components/AuthCheck.tsx — updated to add `card--white` on fallback button; conservative sweep completed for approve-related use.

--- a/migrate/PAGES-QUEUE.md
+++ b/migrate/PAGES-QUEUE.md
@@ -30,6 +30,7 @@ Other pages (alphabetical):
 Completed (recently finished):
 
  - pages/enter.tsx (branch: migrate/pages-enter)
+ - pages/rsvp/index.tsx (branch: migrate/pages-rsvp) — page-level body tokens applied; basic structure added with `text-blog-black dark:text-blog-white`.
 
 Notes:
 


### PR DESCRIPTION
This pull request migrates the `apps/web/pages/rsvp/index.tsx` page to use the new page-level styling tokens and updates related documentation to reflect the migration. The changes include refactoring the page to use the standard Next.js page type, applying theme-aware text color classes, and updating migration tracking files.

Page migration and styling updates:

* Refactored `apps/web/pages/rsvp/index.tsx` to use the `NextPage` type, wrapped content in a `<main>` element, and applied theme-aware text color classes (`text-blog-black dark:text-blog-white`).
* Updated `migrate/PAGES-QUEUE.md` to mark `pages/rsvp/index.tsx` as completed, noting the application of page-level body tokens and basic structure.
* Updated `migrate/COMPONENTS-MIGRATED.md` to indicate that `apps/web/pages/rsvp/index.tsx` has been inspected and no component changes were required.

Documentation and design guidance:

* Added a note to `.github/copilot-instructions.md` about using theme-aware card backgrounds for cards that should adapt to the current theme (e.g., pricing cards).