### PR TITLE
migrate(pages): privacy-policy — add page-level background tokens and…

### DIFF
--- a/apps/web/pages/privacy-policy/index.tsx
+++ b/apps/web/pages/privacy-policy/index.tsx
@@ -12,7 +12,7 @@ const PrivacyPolicy: NextPage = () => {
         <title>Privacy & Cookie Policy - swapnilsrivastava.eu</title>
         <meta name="description" content="Our privacy and cookie policy explains how we use cookies and process your data." />
       </Head>
-      <div className="container mx-auto px-4 py-8 text-blog-black dark:text-blog-white">
+      <div className="container mx-auto px-4 py-8 text-blog-black dark:text-blog-white bg-blog-white dark:bg-fun-blue-500 min-h-screen">
         <h1 className="text-3xl font-bold mb-6 text-blog-black dark:text-blog-white">
           <FormattedMessage
             id="privacy-policy-title"
@@ -22,14 +22,14 @@ const PrivacyPolicy: NextPage = () => {
         </h1>
         
         <section className="mb-8">
-          <h2 className="text-2xl font-bold mb-4 dark:text-white">
+          <h2 className="text-2xl font-bold mb-4 dark:text-blog-white">
             <FormattedMessage
               id="privacy-policy-overview-title"
               description="Overview"
               defaultMessage="Overview"
             />
           </h2>
-          <p className="mb-4 dark:text-white">
+          <p className="mb-4 dark:text-blog-white">
             <FormattedMessage
               id="privacy-policy-overview-text"
               description="This Privacy & Cookie Policy explains how we collect, use, and protect your information when you visit our website. We are committed to ensuring the privacy and security of your data."
@@ -39,13 +39,13 @@ const PrivacyPolicy: NextPage = () => {
         </section>
         
         <section className="mb-8">
-          <h2 className="text-2xl font-bold mb-4 dark:text-white">Cookie Policy</h2>
-          <p className="mb-4 dark:text-white">
+          <h2 className="text-2xl font-bold mb-4 dark:text-blog-white">Cookie Policy</h2>
+          <p className="mb-4 dark:text-blog-white">
             Our website uses cookies to enhance your browsing experience. Here&apos;s how we use them:
           </p>
           
-          <h3 className="text-xl font-semibold mb-2 dark:text-white">Necessary Cookies</h3>
-          <p className="mb-4 dark:text-white">
+          <h3 className="text-xl font-semibold mb-2 dark:text-blog-white">Necessary Cookies</h3>
+          <p className="mb-4 dark:text-blog-white">
             These cookies are essential for the website to function properly. They enable core 
             functionality such as security, account management, and session management. You cannot 
             disable these cookies through our system.
@@ -78,8 +78,8 @@ const PrivacyPolicy: NextPage = () => {
             </tbody>
           </table>
           
-          <h3 className="text-xl font-semibold mb-2 dark:text-white">Preference Cookies</h3>
-          <p className="mb-4 dark:text-white">
+          <h3 className="text-xl font-semibold mb-2 dark:text-blog-white">Preference Cookies</h3>
+          <p className="mb-4 dark:text-blog-white">
             These cookies allow the website to remember choices you make and provide enhanced, personalized features.
           </p>
           
@@ -100,8 +100,8 @@ const PrivacyPolicy: NextPage = () => {
             </tbody>
           </table>
           
-          <h3 className="text-xl font-semibold mb-2 dark:text-white">Analytics Cookies</h3>
-          <p className="mb-4 dark:text-white">
+          <h3 className="text-xl font-semibold mb-2 dark:text-blog-white">Analytics Cookies</h3>
+          <p className="mb-4 dark:text-blog-white">
             These cookies allow us to count visits and traffic sources so we can measure and improve 
             the performance of our site.
           </p>
@@ -128,8 +128,8 @@ const PrivacyPolicy: NextPage = () => {
             </tbody>
           </table>
           
-          <h3 className="text-xl font-semibold mb-2 dark:text-white">AI/Personalization Cookies</h3>
-          <p className="mb-4 dark:text-white">
+          <h3 className="text-xl font-semibold mb-2 dark:text-blog-white">AI/Personalization Cookies</h3>
+          <p className="mb-4 dark:text-blog-white">
             These cookies are used to provide personalized experiences and content based on your interactions.
           </p>
           
@@ -155,8 +155,8 @@ const PrivacyPolicy: NextPage = () => {
             </tbody>
           </table>
           
-          <h3 className="text-xl font-semibold mb-2 dark:text-white">Managing Your Cookie Preferences</h3>
-          <p className="dark:text-white">
+          <h3 className="text-xl font-semibold mb-2 dark:text-blog-white">Managing Your Cookie Preferences</h3>
+          <p className="dark:text-blog-white">
             You can change your cookie preferences at any time by clicking the &quot;Cookie Preferences&quot; 
             button at the bottom left corner of any page.
           </p>
@@ -164,7 +164,7 @@ const PrivacyPolicy: NextPage = () => {
         
         <div className="mt-8">
           <Link href="/" legacyBehavior>
-            <a className="text-[#1249de] hover:text-[#385dc5] dark:text-[#12dea8] dark:hover:text-[#385dc5] flex items-center gap-2">
+            <a className="text-fun-blue-100 hover:text-[#385dc5] dark:text-[#12dea8] dark:hover:text-[#385dc5] flex items-center gap-2">
               <FontAwesomeIcon icon={faArrowLeft} className="h-4 w-4" />
               <span>
                 <FormattedMessage id="privacy.back_to_home" defaultMessage="Back to Home" />

--- a/migrate/COMPONENTS-MIGRATED.md
+++ b/migrate/COMPONENTS-MIGRATED.md
@@ -26,6 +26,8 @@ Completed (migrated and verified):
 - Inspected for this migration: `apps/web/pages/pics/index.tsx` — simple image page, no component changes required.
  - Inspected for this migration: `apps/web/components/CheckoutButton.tsx` — no component-level changes required.
 
+- Inspected for this migration: `apps/web/pages/privacy-policy/index.tsx` — no component changes required.
+
 Inspected / Notes:
 - apps/web/components/AuthCheck.tsx — updated to add `card--white` on fallback button; conservative sweep completed for approve-related use.
 - apps/web/components/PostFeed.tsx — updated to enforce `card--white` on post cards and switched content text to `text-black` for stronger contrast.

--- a/migrate/PAGES-QUEUE.md
+++ b/migrate/PAGES-QUEUE.md
@@ -30,6 +30,10 @@ Other pages (alphabetical):
 Completed (recently finished):
 
  - pages/enter.tsx (branch: migrate/pages-enter)
+ - pages/rsvp/index.tsx (branch: migrate/pages-rsvp) — page-level body tokens applied; basic structure added with `text-blog-black dark:text-blog-white`.
+ - pages/success.tsx (branch: migrate/pages-success) — page-level body tokens applied; success card annotated with `card--white`.
+ - pages/user-preferences.tsx (branch: migrate/pages-user-preferences) — page-level background and tokens applied.
+ - pages/privacy-policy/index.tsx (branch: migrate/pages-privacy-policy) — page-level background and tokens applied; corrected dark mode text classes.
 
 Notes:
 


### PR DESCRIPTION
This pull request updates the privacy policy page to improve visual consistency and accessibility, especially in dark mode. The changes focus on applying the correct background and text color tokens, ensuring that all headings and paragraphs use the appropriate class names, and updating migration documentation to reflect these improvements.

**Visual and Accessibility Improvements:**

* Applied `bg-blog-white dark:bg-fun-blue-500 min-h-screen` to the main container in `privacy-policy/index.tsx` for consistent background in both light and dark modes.
* Updated all heading and paragraph elements to use `dark:text-blog-white` instead of the generic `dark:text-white` for improved dark mode readability. [[1]](diffhunk://#diff-f1bd866f204bb6bf2ea42404783157a478e14ddff2842cc3b16a6ae92f22272eL25-R32) [[2]](diffhunk://#diff-f1bd866f204bb6bf2ea42404783157a478e14ddff2842cc3b16a6ae92f22272eL42-R48) [[3]](diffhunk://#diff-f1bd866f204bb6bf2ea42404783157a478e14ddff2842cc3b16a6ae92f22272eL81-R82) [[4]](diffhunk://#diff-f1bd866f204bb6bf2ea42404783157a478e14ddff2842cc3b16a6ae92f22272eL103-R104) [[5]](diffhunk://#diff-f1bd866f204bb6bf2ea42404783157a478e14ddff2842cc3b16a6ae92f22272eL131-R132) [[6]](diffhunk://#diff-f1bd866f204bb6bf2ea42404783157a478e14ddff2842cc3b16a6ae92f22272eL158-R167)
* Changed the "Back to Home" link color to use `text-fun-blue-100` for better contrast and consistency.

**Documentation Updates:**

* Added migration inspection note for `privacy-policy/index.tsx` to `COMPONENTS-MIGRATED.md`.
* Marked `privacy-policy/index.tsx` as completed in `PAGES-QUEUE.md`, noting page-level background and token application and correction of dark mode text classes.… correct dark mode text classes; update migration docs