### PR TITLE
migrate(pages): product-detail — adjust padding to match other pages …

### DIFF
--- a/apps/web/pages/product-detail/index.tsx
+++ b/apps/web/pages/product-detail/index.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
+import type { NextPage } from 'next';
 
-function ProductDetail() {
+const ProductDetail: NextPage = () => {
   return (
     <>
-      <div className="flex flex-wrap justify-center">
-        <div className="font-poppins lg:text-5xl text-3xl dark:text-blog-white text-blog-black p-10">
+      <div className="flex flex-wrap justify-center bg-blog-white dark:bg-fun-blue-500 min-h-screen">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 font-poppins lg:text-5xl text-3xl dark:text-blog-white text-blog-black">
             <FormattedMessage
                 id="product-detail-heading"
                 description="Product Detail" // Description should be a string literal

--- a/migrate/COMPONENTS-MIGRATED.md
+++ b/migrate/COMPONENTS-MIGRATED.md
@@ -33,6 +33,8 @@ Inspected / Notes:
 Recent edits were pushed on branches: `migrate/pages-approve-components`, `migrate/pages-approve-slug`.
  - `pages/index.tsx` migrated (branch: `migrate/pages-index`) — inspected `PostList` and `HorizontalScrollTech` (no component-level changes required).
 
+- Inspected for this migration: `apps/web/pages/product-detail/index.tsx` — no component changes required.
+
 Policy:
 - Migrate a component on the first page that requires it.
 - Add its path below so subsequent page migrations skip re-migrating it.

--- a/migrate/PAGES-QUEUE.md
+++ b/migrate/PAGES-QUEUE.md
@@ -30,6 +30,11 @@ Other pages (alphabetical):
 Completed (recently finished):
 
  - pages/enter.tsx (branch: migrate/pages-enter)
+ - pages/rsvp/index.tsx (branch: migrate/pages-rsvp) — page-level body tokens applied; basic structure added with `text-blog-black dark:text-blog-white`.
+ - pages/success.tsx (branch: migrate/pages-success) — page-level body tokens applied; success card annotated with `card--white`.
+ - pages/user-preferences.tsx (branch: migrate/pages-user-preferences) — page-level background and tokens applied.
+ - pages/privacy-policy/index.tsx (branch: migrate/pages-privacy-policy) — page-level background and tokens applied; corrected dark mode text classes.
+ - pages/product-detail/index.tsx (branch: migrate/pages-product-detail) — page-level background and tokens applied; added NextPage typing.
 
 Notes:
 


### PR DESCRIPTION
This pull request migrates the `apps/web/pages/product-detail/index.tsx` page to align with the updated design and typing conventions. The most important changes include updating the page to use Next.js's `NextPage` type, applying consistent page-level background and layout tokens, and documenting the migration in the relevant tracking files.

**Page migration and styling updates:**

* Refactored `ProductDetail` to use the `NextPage` type and converted it from a function declaration to a typed arrow function for improved type safety and consistency.
* Applied page-level background (`bg-blog-white dark:bg-fun-blue-500`) and layout tokens (`min-h-screen`, `max-w-7xl`, responsive padding) to ensure consistent design and dark mode support.

**Documentation and migration tracking:**

* Added an entry to `migrate/COMPONENTS-MIGRATED.md` noting that `apps/web/pages/product-detail/index.tsx` was inspected and no further component changes were required.
* Updated `migrate/PAGES-QUEUE.md` to mark `pages/product-detail/index.tsx` as completed, with page-level background and tokens applied and NextPage typing added.…(px-4 sm:px-6 lg:px-8 py-12)