### PR TITLE
migrate(pages): products — add NextPage typing; update migration docs

### DIFF
--- a/apps/web/pages/products/index.tsx
+++ b/apps/web/pages/products/index.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import toast from "react-hot-toast";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faShoppingCart, faFilter, faSearch } from "@fortawesome/free-solid-svg-icons";
+import type { NextPage } from 'next';
 
 // CSS
 import styles from "../../styles/Admin.module.css";
@@ -18,7 +19,7 @@ import { RootState } from "../../lib/interfaces/interface";
 // Supabase
 import { supaClient } from "../../supa-client";
 
-function Products() {
+const Products: NextPage = () => {
   const intl = useIntl();
 
   const selectUser = (state: RootState) => state.cart;

--- a/migrate/COMPONENTS-MIGRATED.md
+++ b/migrate/COMPONENTS-MIGRATED.md
@@ -33,6 +33,8 @@ Inspected / Notes:
 Recent edits were pushed on branches: `migrate/pages-approve-components`, `migrate/pages-approve-slug`.
  - `pages/index.tsx` migrated (branch: `migrate/pages-index`) — inspected `PostList` and `HorizontalScrollTech` (no component-level changes required).
 
+- Inspected for this migration: `apps/web/pages/products/index.tsx` — no component changes required.
+
 Policy:
 - Migrate a component on the first page that requires it.
 - Add its path below so subsequent page migrations skip re-migrating it.

--- a/migrate/PAGES-QUEUE.md
+++ b/migrate/PAGES-QUEUE.md
@@ -30,6 +30,12 @@ Other pages (alphabetical):
 Completed (recently finished):
 
  - pages/enter.tsx (branch: migrate/pages-enter)
+ - pages/rsvp/index.tsx (branch: migrate/pages-rsvp) — page-level body tokens applied; basic structure added with `text-blog-black dark:text-blog-white`.
+ - pages/success.tsx (branch: migrate/pages-success) — page-level body tokens applied; success card annotated with `card--white`.
+ - pages/user-preferences.tsx (branch: migrate/pages-user-preferences) — page-level background and tokens applied.
+ - pages/privacy-policy/index.tsx (branch: migrate/pages-privacy-policy) — page-level background and tokens applied; corrected dark mode text classes.
+ - pages/product-detail/index.tsx (branch: migrate/pages-product-detail) — page-level background and tokens applied; added NextPage typing.
+ - pages/products/index.tsx (branch: migrate/pages-products) — added NextPage typing; page-level background and tokens already present.
 
 Notes:
 


### PR DESCRIPTION
This pull request updates the `apps/web/pages/products/index.tsx` page to use the `NextPage` type for improved type safety and consistency with Next.js conventions. Additionally, it documents the migration and inspection status for this page in the project migration tracking files.

TypeScript/Next.js improvements:

* Refactored the `Products` component to use the `NextPage` type and updated its declaration to a constant with an arrow function for better type safety and alignment with Next.js standards (`apps/web/pages/products/index.tsx`). [[1]](diffhunk://#diff-4f89f2e00b5d5a2317981db666a5d08bd42722754d72e5439b9b98b2b83d11a5R8) [[2]](diffhunk://#diff-4f89f2e00b5d5a2317981db666a5d08bd42722754d72e5439b9b98b2b83d11a5L21-R22)

Migration documentation updates:

* Added an entry to `migrate/COMPONENTS-MIGRATED.md` indicating that `apps/web/pages/products/index.tsx` was inspected for migration and required no component-level changes.
* Updated `migrate/PAGES-QUEUE.md` to mark `pages/products/index.tsx` as completed, noting the addition of `NextPage` typing and confirming that page-level background and tokens were already present.