### PR TITLE
Update ThemeColorPicker mobile view to appear below navbar

### DIFF
--- a/apps/web/components/ThemeColorPicker.tsx
+++ b/apps/web/components/ThemeColorPicker.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useThemeSettings } from '../lib/use-theme-settings';
 import { useIntl } from 'react-intl';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPalette } from '@fortawesome/free-solid-svg-icons';
+import { faPalette, faXmark } from '@fortawesome/free-solid-svg-icons';
 import RoundButton from './RoundButton';
 
 const themeColors = [
@@ -17,31 +17,30 @@ export default function ThemeColorPicker() {
   const { color: activeColor, setColor } = useThemeSettings();
   const [mounted, setMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const intl = useIntl();
 
   useEffect(() => {
     setMounted(true);
     
     function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
         setIsOpen(false);
       }
     }
 
-    document.addEventListener('mousedown', handleClickOutside);
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, []);
+  }, [isOpen]);
 
   if (!mounted) {
     return (
       <div className="relative">
-        {/* Mobile Skeleton */}
-        <div className="md:hidden w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse" />
-         
-        {/* Desktop Skeleton */}
+        <div className="md:hidden w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse m-0.5" />
         <div className="hidden md:flex gap-2 p-1.5 bg-white/50 dark:bg-gray-800/50 rounded-full border border-gray-100 dark:border-gray-700">
           {themeColors.map((c) => (
             <div key={c.name} className="w-6 h-6 rounded-full bg-gray-200 dark:bg-gray-700" />
@@ -52,49 +51,70 @@ export default function ThemeColorPicker() {
   }
 
   return (
-    <div className="relative" ref={dropdownRef}>
-      {/* Mobile Trigger Button */}
-      <div
-        onClick={() => setIsOpen(!isOpen)}
-        className="md:hidden flex items-center justify-center cursor-pointer"
-        aria-label={intl.formatMessage({ id: 'theme-picker-label', defaultMessage: 'Change theme color' })}
-        role="button"
-        aria-expanded={isOpen}
-      >
-        <RoundButton>
-          <FontAwesomeIcon icon={faPalette} size="lg" />
-        </RoundButton>
-      </div>
+    <div className="relative h-9 flex items-center" ref={wrapperRef}>
+      {/* Mobile: Animated Container */}
+      <div className="md:hidden">
+        {/* Trigger Button - Rotates when open */}
+        <div 
+          className={`transition-all duration-300 ease-in-out transform ${
+            isOpen ? 'rotate-180' : 'rotate-0'
+          }`}
+          onClick={() => setIsOpen(!isOpen)}
+          role="button"
+          aria-label={intl.formatMessage({ id: 'theme-picker-label', defaultMessage: 'Change theme color' })}
+        >
+          <RoundButton>
+            {isOpen ? (
+                 <FontAwesomeIcon icon={faXmark} size="lg" />
+            ) : (
+                <FontAwesomeIcon icon={faPalette} size="lg" />
+            )}
+          </RoundButton>
+        </div>
 
-      {/* Mobile Dropdown Panel */}
-      {isOpen && (
-        <div className="md:hidden absolute top-12 left-1/2 transform -translate-x-1/2 z-50 flex gap-2 p-3 bg-white dark:bg-gray-900 rounded-full border border-gray-100 dark:border-gray-800 shadow-xl animate-fadeIn">
-            {themeColors.map(({ name, labelId, hex }) => {
+        {/* Floating Palette Dropdown (Below Navbar) */}
+        {isOpen && (
+            <div 
+            className="
+                fixed top-20 left-0 right-0 p-4 
+                flex justify-center items-center 
+                bg-white/95 dark:bg-gray-900/95 backdrop-blur-md 
+                border-b border-gray-100 dark:border-gray-800 
+                shadow-lg z-40 animate-slideDown
+            "
+            onClick={(e) => e.stopPropagation()} // Prevent close when clicking panel
+            >
+            <div className="flex gap-4 p-2">
+                {themeColors.map(({ name, labelId, hex }) => {
                 const isActive = activeColor === name;
                 return (
                     <button
-                        key={name}
-                        onClick={() => {
-                            setColor(name);
-                            setIsOpen(false);
-                        }}
-                        className={`
-                        w-8 h-8 rounded-full transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-gray-400
-                        ${isActive ? 'ring-2 ring-offset-2 ring-gray-900 dark:ring-gray-100 scale-110' : ''}
-                        `}
-                        style={{ backgroundColor: hex }}
-                        aria-label={intl.formatMessage({ id: labelId })}
+                    key={name}
+                    onClick={() => {
+                        setColor(name);
+                        setIsOpen(false);
+                    }}
+                    className={`
+                        w-10 h-10 rounded-full transition-transform duration-200
+                        ${isActive 
+                        ? 'ring-4 ring-offset-2 ring-gray-900 dark:ring-gray-100 scale-110 shadow-xl' 
+                        : 'hover:scale-110 border-2 border-transparent shadow-md'
+                        }
+                    `}
+                    style={{ backgroundColor: hex }}
+                    aria-label={intl.formatMessage({ id: labelId })}
                     />
                 );
-            })}
-        </div>
-      )}
+                })}
+            </div>
+            </div>
+        )}
+      </div>
 
-      {/* Desktop Inline View */}
+      {/* Desktop Inline View (Unchanged) */}
       <div className="hidden md:flex items-center gap-2 p-1.5 bg-white/80 dark:bg-gray-900/80 backdrop-blur-md rounded-full border border-gray-100 dark:border-gray-800 shadow-lg transition-colors duration-300">
         {themeColors.map(({ name, labelId, hex }) => {
           const isActive = activeColor === name;
-
           return (
             <button
               key={name}


### PR DESCRIPTION
This pull request refactors and enhances the `ThemeColorPicker` component to improve the mobile user experience and code maintainability. The main changes include a redesigned mobile dropdown, improved click-outside handling, updated button visuals, and accessibility improvements.

**Mobile UI/UX improvements:**

* Redesigned the mobile palette dropdown to use a floating, centered panel with a blurred background and slide-down animation, making it more visually distinct and accessible. The dropdown now appears fixed below the navbar instead of as an absolute-positioned element.
* Updated the mobile trigger button: it now smoothly rotates when toggled and switches between the palette and close (`faXmark`) icons, providing clearer feedback. [[1]](diffhunk://#diff-d19c47fbe61d507fd0cbe5993e32f8c4088ef0a604933dedf6df9ef4a62303feL5-R5) [[2]](diffhunk://#diff-d19c47fbe61d507fd0cbe5993e32f8c4088ef0a604933dedf6df9ef4a62303feL55-R87)

**Accessibility and interaction:**

* Improved click-outside detection by renaming `dropdownRef` to `wrapperRef` and updating the effect to only attach the event listener when the dropdown is open, preventing unnecessary listeners and potential memory leaks.
* Prevented the dropdown from closing when clicking inside the palette panel, ensuring a smoother user experience.

**Visual and code consistency:**

* Enhanced the appearance of color buttons on mobile: active colors have a more prominent ring and shadow, while inactive buttons have subtle borders and hover effects.
* Updated the loading skeletons for better alignment and sizing on mobile.

These changes collectively make the theme color picker more intuitive and visually appealing, especially on mobile devices.